### PR TITLE
- Using string instead of int for station ids

### DIFF
--- a/WeatherForecast/Interfaces/IForecastService.cs
+++ b/WeatherForecast/Interfaces/IForecastService.cs
@@ -4,6 +4,11 @@ namespace WeatherForecast.Interfaces
 {
     public interface IForecastService
     {
-        Task<Forecast> GetForecastForStation(int stationId);
+        /// <summary>
+        /// Gets a complete forecast for a given weather station
+        /// </summary>
+        /// <param name="stationId"></param>
+        /// <returns>An object containing Station name, last updated and all forecast entries for the station</returns>
+        Task<Forecast> GetForecastForStation(string stationId);
     }
 }

--- a/WeatherForecast/Program.cs
+++ b/WeatherForecast/Program.cs
@@ -2,10 +2,10 @@
 using WeatherForecast.Services;
 using WeatherForecast.Models;
 
-Dictionary<string, int> stations = new Dictionary<string, int>
+Dictionary<string, string> stations = new Dictionary<string, string>
 {
-    ["reykjavík"] = 1,
-    ["akureyri"] = 3471
+    ["reykjavík"] = "1",
+    ["akureyri"] = "3471"
 };
 
 var forecastService = new ForecastService();

--- a/WeatherForecast/Services/ForecastService.cs
+++ b/WeatherForecast/Services/ForecastService.cs
@@ -39,7 +39,7 @@ namespace WeatherForecast.Services
         };
 
 
-        public async Task<Forecast> GetForecastForStation(int stationId)
+        public async Task<Forecast> GetForecastForStation(string stationId)
         {
             var response = await GetForecast(stationId);
             var xmlDoc = new XmlDocument();
@@ -72,7 +72,7 @@ namespace WeatherForecast.Services
             }
             return forecast;
         }
-        private async Task<HttpResponseMessage> GetForecast(int stationId)
+        private async Task<HttpResponseMessage> GetForecast(string stationId)
         {
             return await _client.GetAsync($"?op_w=xml&type=forec&lang=is&view=xml&ids={stationId}");
         }


### PR DESCRIPTION
Adds a summary for GetForecastForStation interface and changes station id param type to string instead of int